### PR TITLE
Added support for separate Swift modules with external types

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,6 +22,7 @@ members = [
   "fixtures/ext-types/guid",
   "fixtures/ext-types/uniffi-one",
   "fixtures/ext-types/lib",
+  "fixtures/ext-types/lib-with-separate-swift-modules/",
 
   # we should roll the above and below up somehow that makes sense...
   "fixtures/external-types/crate-one",

--- a/docs/manual/src/udl/ext_types_external.md
+++ b/docs/manual/src/udl/ext_types_external.md
@@ -70,6 +70,26 @@ rust-crate-name = "kotlin.package.name"
 
 ### Swift
 
-For Swift, you must compile all generated `.swift` files together in a single
-module since the generate code expects that it can access external types
-without importing them.
+For Swift, there are 2 ways to use the UniFFI-generated Swift code:
+  - Compile all source files together in the same module.
+  - Compile each source file into a different module.
+
+By default, UniFFI assumes that the source files will be compiled together, so
+external types will be automatically available and nothing needs to be configured.
+
+If you compile each source file into a different module, then you need to
+add configuration to `uniffi.toml`.
+
+```
+[bindings.swift.external_types]
+in_different_modules = true
+```
+
+By default, UniFFI assumes the module name is the same as Rust crate name
+specified in the UDL file (with hyphens replaced with underscores). You can
+override this with the `bindings.swift.external_types.module_names` config key:
+
+```
+[bindings.swift.external_types.module_names]
+my-rust-crate-name = "my_swift_module_name"
+```

--- a/fixtures/ext-types/lib-with-separate-swift-modules/Cargo.toml
+++ b/fixtures/ext-types/lib-with-separate-swift-modules/Cargo.toml
@@ -1,0 +1,41 @@
+[package]
+name = "uniffi-fixture-ext-types-swift-separate-modules"
+edition = "2021"
+version = "0.21.0"
+authors = ["Firefox Sync Team <sync-team@mozilla.com>"]
+license = "MPL-2.0"
+publish = false
+
+[package.metadata.uniffi.testing]
+external-crates = [
+    "uniffi-fixture-ext-types-guid",
+    "uniffi-fixture-ext-types-lib-one",
+    "uniffi-example-custom-types",
+]
+swift-use-separate-modules = true
+
+[lib]
+crate-type = ["lib", "cdylib"]
+name = "uniffi_ext_types_lib"
+
+[dependencies]
+anyhow = "1"
+bytes = "1.0"
+uniffi = {path = "../../../uniffi", features=["builtin-bindgen"]}
+
+uniffi-fixture-ext-types-lib-one = {path = "../uniffi-one"}
+uniffi-fixture-ext-types-guid = {path = "../guid"}
+
+# Reuse one of our examples.
+uniffi-example-custom-types = {path = "../../../examples/custom-types"}
+
+url = "2.2"
+
+[build-dependencies]
+uniffi_build = {path = "../../../uniffi_build", features=["builtin-bindgen"]}
+
+
+
+[dev-dependencies]
+uniffi_bindgen = {path = "../../../uniffi_bindgen"}
+uniffi_macros = {path = "../../../uniffi_macros"}

--- a/fixtures/ext-types/lib-with-separate-swift-modules/README.md
+++ b/fixtures/ext-types/lib-with-separate-swift-modules/README.md
@@ -1,0 +1,3 @@
+This is basically the same as the uniffi-fixture-ext-types fixture found in
+`../lib`.  The only difference is that this crate configures the swift tests to
+compile each source file into a separate module so that we can test that mode.

--- a/fixtures/ext-types/lib-with-separate-swift-modules/build.rs
+++ b/fixtures/ext-types/lib-with-separate-swift-modules/build.rs
@@ -1,0 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+fn main() {
+    uniffi_build::generate_scaffolding("./src/ext-types-lib.udl").unwrap();
+}

--- a/fixtures/ext-types/lib-with-separate-swift-modules/src/ext-types-lib.udl
+++ b/fixtures/ext-types/lib-with-separate-swift-modules/src/ext-types-lib.udl
@@ -1,0 +1,40 @@
+namespace imported_types_lib {
+    CombinedType get_combined_type(optional CombinedType? value);
+};
+
+// A type defined in a .udl file in the `uniffi-one` crate (ie, in
+// `../../uniffi-one/src/uniffi-one.udl`)
+[External="uniffi-one"]
+typedef extern UniffiOneType;
+
+// A "wrapped" type defined in the guid crate (ie, defined in `../../guid/src/lib.rs` and
+// "declared" in `../../guid/src/guid.udl`). But it's still "external" from our POV,
+// So same as the `.udl` type above!
+[External="ext-types-guid"]
+typedef extern Guid;
+
+// And re-use the `custom-types` example - this exposes `Url` and `Handle`
+[External="custom-types"]
+typedef extern Url;
+
+[External="custom-types"]
+typedef extern Handle;
+
+// And a new type here to tie them all together.
+dictionary CombinedType {
+    UniffiOneType uot;
+    sequence<UniffiOneType> uots;
+    UniffiOneType? maybe_uot;
+
+    Guid guid;
+    sequence<Guid> guids;
+    Guid? maybe_guid;
+
+    Url url;
+    sequence<Url> urls;
+    Url? maybe_url;
+
+    Handle handle;
+    sequence<Handle> handles;
+    Handle? maybe_handle;
+};

--- a/fixtures/ext-types/lib-with-separate-swift-modules/src/lib.rs
+++ b/fixtures/ext-types/lib-with-separate-swift-modules/src/lib.rs
@@ -1,0 +1,53 @@
+use custom_types::Handle;
+use ext_types_guid::Guid;
+use uniffi_one::UniffiOneType;
+use url::Url;
+
+pub struct CombinedType {
+    pub uot: UniffiOneType,
+    pub uots: Vec<UniffiOneType>,
+    pub maybe_uot: Option<UniffiOneType>,
+
+    pub guid: Guid,
+    pub guids: Vec<Guid>,
+    pub maybe_guid: Option<Guid>,
+
+    pub url: Url,
+    pub urls: Vec<Url>,
+    pub maybe_url: Option<Url>,
+
+    pub handle: Handle,
+    pub handles: Vec<Handle>,
+    pub maybe_handle: Option<Handle>,
+}
+
+fn get_combined_type(existing: Option<CombinedType>) -> CombinedType {
+    existing.unwrap_or_else(|| CombinedType {
+        uot: UniffiOneType {
+            sval: "hello".to_string(),
+        },
+        uots: vec![
+            UniffiOneType {
+                sval: "first of many".to_string(),
+            },
+            UniffiOneType {
+                sval: "second of many".to_string(),
+            },
+        ],
+        maybe_uot: None,
+
+        guid: Guid("a-guid".into()),
+        guids: vec![Guid("b-guid".into()), Guid("c-guid".into())],
+        maybe_guid: None,
+
+        url: Url::parse("http://example.com/").unwrap(),
+        urls: vec![],
+        maybe_url: None,
+
+        handle: Handle(123),
+        handles: vec![Handle(1), Handle(2), Handle(3)],
+        maybe_handle: Some(Handle(4)),
+    })
+}
+
+include!(concat!(env!("OUT_DIR"), "/ext-types-lib.uniffi.rs"));

--- a/fixtures/ext-types/lib-with-separate-swift-modules/tests/bindings/test_imported_types.swift
+++ b/fixtures/ext-types/lib-with-separate-swift-modules/tests/bindings/test_imported_types.swift
@@ -1,0 +1,14 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import imported_types_lib
+import Foundation
+
+let ct = getCombinedType(value: nil)
+assert(ct.uot.sval == "hello")
+assert(ct.guid ==  "a-guid")
+assert(ct.url ==  URL(string: "http://example.com/"))
+
+let ct2 = getCombinedType(value: ct)
+assert(ct == ct2)

--- a/fixtures/ext-types/lib-with-separate-swift-modules/tests/test_generated_bindings.rs
+++ b/fixtures/ext-types/lib-with-separate-swift-modules/tests/test_generated_bindings.rs
@@ -1,0 +1,5 @@
+uniffi_macros::build_foreign_language_testcases!(
+    "tests/bindings/test_imported_types.swift",
+    // No need to test other languages, since this crate only changes the Swift configuration
+    // (see ../README.md)
+);

--- a/fixtures/ext-types/lib-with-separate-swift-modules/uniffi.toml
+++ b/fixtures/ext-types/lib-with-separate-swift-modules/uniffi.toml
@@ -1,0 +1,2 @@
+[bindings.swift.external_types]
+in_different_modules = true

--- a/uniffi_bindgen/src/bindings/swift/templates/ExternalType.swift
+++ b/uniffi_bindgen/src/bindings/swift/templates/ExternalType.swift
@@ -1,0 +1,4 @@
+{%- if self.external_types_in_different_modules() %}
+{# This import will bring in both the type itself and the FfiConverter for it #}
+{{ self.add_import(self.external_type_module_name(crate_name).borrow()) }}
+{%- endif %}

--- a/uniffi_bindgen/src/bindings/swift/templates/Types.swift
+++ b/uniffi_bindgen/src/bindings/swift/templates/Types.swift
@@ -64,6 +64,9 @@
 {%- when Type::Custom { name, builtin } %}
 {%- include "CustomType.swift" %}
 
+{%- when Type::External { crate_name, name } %}
+{%- include "ExternalType.swift" %}
+
 {%- when Type::Enum(name) %}
 {%- include "EnumTemplate.swift" %}
 

--- a/uniffi_testing/src/lib.rs
+++ b/uniffi_testing/src/lib.rs
@@ -23,6 +23,10 @@ struct UniFFITestingMetadata {
     /// directory
     #[serde(rename = "external-crates")]
     external_crates: Option<Vec<String>>,
+    /// Should generated files for Swift external crates be compiled as separate modules?  The
+    /// default is to compile them all together into 1 module.
+    #[serde(default, rename = "swift-use-separate-modules")]
+    swift_use_separate_modules: bool,
 }
 
 // A source to compile for a test
@@ -130,6 +134,13 @@ impl UniFFITestHelper {
         match cdylib_files.len() {
             1 => Ok(cdylib_files[0].to_owned()),
             n => bail!("Found {n} cdylib files for {}", package.name),
+        }
+    }
+
+    pub fn swift_use_separate_modules(&self) -> bool {
+        match &self.metadata {
+            Some(metadata) => metadata.swift_use_separate_modules,
+            None => false,
         }
     }
 


### PR DESCRIPTION
(This is based off of #1389, let's merge that first)

Added support for build processes where each generated `.swift` file is compiled into its own module rather than compiling all files together. This means that we need imports to make external types work.

- Added test fixture and updated the testing code to test this
- Added config code to allow the user to choose their mode
- Updated the docs to describe the config options