### PR TITLE
Allow 'External' errors from crate X to be used in crate Y

### DIFF
--- a/uniffi_bindgen/src/interface/mod.rs
+++ b/uniffi_bindgen/src/interface/mod.rs
@@ -1118,7 +1118,9 @@ fn throws_name(throws: &Option<Type>) -> Option<&str> {
     // Type has no `name()` method, just `canonical_name()` which isn't what we want.
     match throws {
         None => None,
-        Some(Type::Enum { name, .. }) | Some(Type::Object { name, .. }) => Some(name),
+        Some(Type::Enum { name, .. })
+        | Some(Type::Object { name, .. })
+        | Some(Type::External { name, .. }) => Some(name),
         _ => panic!("unknown throw type: {throws:?}"),
     }
 }


### PR DESCRIPTION
Allow errors from crate X be used in crate Y, fixes;

```
thread 'main' panicked at /Users/sajjon/.cargo/git/checkouts/uniffi-rs-b4f31d82d8259f10/4b65c37/uniffi_bindgen/src/interface/mod.rs:1122:14:
unknown throw type: Some(External { module_path: "sargoncommon", name: "CommonError", namespace: "sargoncommon", kind: DataClass, tagged: false })
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```